### PR TITLE
fix "Invalid function: awesome-pair-ignore-errors" bug.

### DIFF
--- a/awesome-pair.el
+++ b/awesome-pair.el
@@ -174,6 +174,11 @@
 \\<awesome-pair-mode-map>"
   )
 
+(defmacro awesome-pair-ignore-errors (body)
+  `(ignore-errors
+     ,body
+     t))
+
 ;;;;;;;;;;;;;;;;; Interactive functions ;;;;;;;;;;;;;;;;;;;;;;
 
 (defun awesome-pair-open-round ()
@@ -1313,11 +1318,6 @@ Just like `paredit-splice-sexp+' style."
                 (goto-char right-parent-pos)
                 (char-before))))
         (and (eq left-parent-char ?\{) (eq right-parent-char ?\}))))))
-
-(defmacro awesome-pair-ignore-errors (body)
-  `(ignore-errors
-     ,body
-     t))
 
 (provide 'awesome-pair)
 


### PR DESCRIPTION
很多命令会报这个错误："Invalid function: awesome-pair-ignore-errors"。我用的是 Emacs 26.2，我估计这是个只有把 awesome-pair 编译成字节码以后才会出现的 bug。

我看代码里 `awesome-pair-ignore-errors` 是有定义的，flycheck（后端是 Emacs 自己的字节码编译器）告诉我 "macro 'awesome-pair-ignore-errors' defined too late"，所以我就把它往前移了一下，现在可以用了。