### PR TITLE
handle python's triple quotes

### DIFF
--- a/awesome-pair.el
+++ b/awesome-pair.el
@@ -293,6 +293,10 @@
          (awesome-pair-wrap-double-quote))
         ((awesome-pair-in-string-p)
          (cond
+          ((and (derived-mode-p 'python-mode)
+                (and (eq (char-before) ?\") (eq (char-after) ?\")))
+           (insert "\"\"")
+           (backward-char))
           ;; When current mode is golang.
           ;; Don't insert \" in string that wrap by `...`
           ((and (derived-mode-p 'go-mode)


### PR DESCRIPTION
Python 的 docstring 经常使用三引号，所以使两边都是引号时，再插入引号不转义。