### PR TITLE
fix error goto-char: Wrong type argument: number-or-marker-p, nil

### DIFF
--- a/awesome-pair.el
+++ b/awesome-pair.el
@@ -1311,6 +1311,8 @@ A and B are strings."
 (defun awesome-pair-current-parse-state ()
   (let ((point (point)))
     (beginning-of-defun)
+    (when (equal point (point))
+      (beginning-of-line))
     (parse-partial-sexp (point) point)))
 
 (defun awesome-pair-string-start+end-points (&optional state)


### PR DESCRIPTION
场景：Python单文件脚本
修复非函数内代码执行 awesome-pair-jump-left/right报错
