### PR TITLE
Avoid positional arguments to define-minor-mode

### DIFF
--- a/awesome-pair.el
+++ b/awesome-pair.el
@@ -193,7 +193,7 @@
 (define-minor-mode awesome-pair-mode
   "Minor mode for auto parenthesis pairing with syntax table.
 \\<awesome-pair-mode-map>"
-  )
+  :group 'awesome-pair)
 
 (defmacro awesome-pair-ignore-errors (body)
   `(ignore-errors


### PR DESCRIPTION
Get rid of the warning "Use keywords rather than deprecated positional arguments to define-minor-mode"  in Emacs 28.1